### PR TITLE
Loosen bundler requirement to anything >= 1.0, Rails 4 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "http://rubygems.org"
 group :development do
   gem "shoulda", ">= 0"
   gem "rdoc", "~> 3.12"
-  gem "bundler", "~> 1.0.0"
+  gem "bundler", ">= 1.0.0"
   gem "jeweler", "~> 1.8.3"
   gem "simplecov", ">= 0"
 end

--- a/lib/has_activity/core.rb
+++ b/lib/has_activity/core.rb
@@ -8,11 +8,19 @@ module HasActivity
     module ClassMethods
 
       def activity_since(*args)
-        scoped.activity_since(*args)
+        if ActiveRecord::VERSION::MAJOR == 4
+          all.activity_since(*args)
+        else
+          scoped.activity_since(*args)
+        end
       end
 
       def activity_between(*args)
-        scoped.activity_between(*args)
+        if ActiveRecord::VERSION::MAJOR == 4
+          all.activity_between(*args)
+        else
+          scoped.activity_between(*args)
+        end
       end
 
     end # ClassMethods


### PR DESCRIPTION
I use Model.all instead of Mode.scope for the has_activity methods. I think this works, but only one way to find out.
